### PR TITLE
Hide uneeded items from AE2

### DIFF
--- a/scripts/jei.zs
+++ b/scripts/jei.zs
@@ -1,3 +1,9 @@
 // hide jei categories
 mods.jei.JEI.hideCategory("appliedenergistics2.grinder");
 mods.jei.JEI.hideCategory("appliedenergistics2.inscriber");
+
+// hide uneeded items
+mods.jei.JEI.removeAndHide(<appliedenergistics2:vibration_chamber>);
+mods.jei.JEI.removeAndHide(<appliedenergistics2:grindstone>);
+mods.jei.JEI.removeAndHide(<appliedenergistics2:inscriber>);
+mods.jei.JEI.removeAndHide(<appliedenergistics2:crank>);


### PR DESCRIPTION
This PR hides the following items from AE2 which have their recipes removed anyways:

- Vibration Chamber
- Grindstone
- Inscriber
- Crank