### PR TITLE
Fix a bug where AE wrenchs are enabled but they don't show up

### DIFF
--- a/config/AppliedEnergistics2/AppliedEnergistics2.cfg
+++ b/config/AppliedEnergistics2/AppliedEnergistics2.cfg
@@ -213,8 +213,8 @@ features {
     }
 
     toolsclassifications {
-        B:CertusQuartzTools=false
-        B:NetherQuartzTools=false
+        B:CertusQuartzTools=true
+        B:NetherQuartzTools=true
         B:PoweredTools=true
     }
 
@@ -227,7 +227,7 @@ features {
         B:PaintBalls=true
         B:QuartzAxe=false
         B:QuartzHoe=false
-        B:QuartzKnife=false
+        B:QuartzKnife=true
         B:QuartzPickaxe=false
         B:QuartzSpade=false
         B:QuartzSword=false


### PR DESCRIPTION
you need to enable  toolsclassifications for them to work and desable the tools manually which are already are
also enabled the knife tool for renaming interfaces so you don't need to use anvil (which uses experience)