### PR TITLE
Add Gregtech Stones to Chisel Groups

### DIFF
--- a/scripts/chisel.zs
+++ b/scripts/chisel.zs
@@ -1,0 +1,8 @@
+import mods.chisel.Carving;
+import crafttweaker.item.IItemStack;
+
+//Add Gregtech Basalt to Chisel Group
+mods.chisel.Carving.addVariation("basalt", <gregtech:stone_smooth:3>);
+
+//Add Gregtech Marble to Chisel Group
+mods.chisel.Carving.addVariation("marble", <gregtech:stone_smooth:2>);


### PR DESCRIPTION
Gregtech Marble and Basalt are not able to be chiseled into Chisel variants. This pull request adds a small script to add Gregtech basalt and marble to the "basalt" and "marble" chisel groups.