### PR TITLE
Add Realbench Nomi-CEu Edition v1.0.4

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -446,6 +446,11 @@
             "projectID": 845779,
             "fileID": 5006537,
             "required": true
+        },
+        {
+            "projectID": 945503,
+            "fileID": 4941450,
+            "required": true
         }
     ]
 }


### PR DESCRIPTION
This PR adds Realbench Nomi-CEu Edition v1.0.4 to GCP.

This mod is a continuation of Realbench, and fixes its dupe bugs. This works well with Crafting Tweaks Unofficial (which is already in the pack).

Essentially:
- Items stay in the Crafting Table
- Items in the Crafting Table are rendered on top
- Other players can collaborate on crafts and see the progress
- Items dropped when Crafting Table is broken